### PR TITLE
feat: add customResponses

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,6 @@ You can modify the status code or headers for any response using the `responseMe
 
 ```typescript
 // Router
-import { DefaultErrorResponse } from "trpc-openapi"
 
 export const appRouter = t.router({
   sayHello: t.procedure
@@ -186,11 +185,12 @@ export const appRouter = t.router({
       path: '/say-hello/{name}',
       extraResponses: {
           400: {
-            ...DefaultErrorResponse,
             description: 'Bad request',
+            content: z.object({ reason: z.string().describe("The reason") }),
           },
-      } /* 👈 */ } })
-    .input(z.object({ name: z.string() /* 👈 */, greeting: z.string() }))
+      }
+    }})
+    .input(z.object({ name: z.string(), greeting: z.string() }))
     .output(z.object({ greeting: z.string() }))
     .mutation(({ input }) => {
       return { greeting: `${input.greeting} ${input.name}!` };
@@ -350,19 +350,21 @@ Please see [full typings here](src/generator/index.ts).
 
 Please see [full typings here](src/types.ts).
 
-| Property         | Type                | Description                                                                                                        | Required | Default                |
-| ---------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------ | -------- | ---------------------- |
-| `enabled`        | `boolean`           | Exposes this procedure to `trpc-openapi` adapters and on the OpenAPI document.                                     | `false`  | `true`                 |
-| `method`         | `HttpMethod`        | HTTP method this endpoint is exposed on. Value can be `GET`, `POST`, `PATCH`, `PUT` or `DELETE`.                   | `true`   | `undefined`            |
-| `path`           | `string`            | Pathname this endpoint is exposed on. Value must start with `/`, specify path parameters using `{}`.               | `true`   | `undefined`            |
-| `protect`        | `boolean`           | Requires this endpoint to use a security scheme.                                                                   | `false`  | `false`                |
-| `summary`        | `string`            | A short summary of the endpoint included in the OpenAPI document.                                                  | `false`  | `undefined`            |
-| `description`    | `string`            | A verbose description of the endpoint included in the OpenAPI document.                                            | `false`  | `undefined`            |
-| `tags`           | `string[]`          | A list of tags used for logical grouping of endpoints in the OpenAPI document.                                     | `false`  | `undefined`            |
-| `headers`        | `ParameterObject[]` | An array of custom headers to add for this endpoint in the OpenAPI document.                                       | `false`  | `undefined`            |
-| `contentTypes`   | `ContentType[]`     | A set of content types specified as accepted in the OpenAPI document.                                              | `false`  | `['application/json']` |
-| `extraResponses` | `ResponsesObject`   | An array of custom responses to add for this endpoint in the OpenAPI document in addition to the default response. | `false`  | `undefined`            |
-| `deprecated`     | `boolean`           | Whether or not to mark an endpoint as deprecated                                                                   | `false`  | `false`                |
+| Property         | Type                               | Description                                                                                                        | Required | Default                |
+| ---------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------- | ---------------------- |
+| `enabled`        | `boolean`                          | Exposes this procedure to `trpc-openapi` adapters and on the OpenAPI document.                                     | `false`  | `true`                 |
+| `method`         | `HttpMethod`                       | HTTP method this endpoint is exposed on. Value can be `GET`, `POST`, `PATCH`, `PUT` or `DELETE`.                   | `true`   | `undefined`            |
+| `path`           | `string`                           | Pathname this endpoint is exposed on. Value must start with `/`, specify path parameters using `{}`.               | `true`   | `undefined`            |
+| `protect`        | `boolean`                          | Requires this endpoint to use a security scheme.                                                                   | `false`  | `false`                |
+| `summary`        | `string`                           | A short summary of the endpoint included in the OpenAPI document.                                                  | `false`  | `undefined`            |
+| `description`    | `string`                           | A verbose description of the endpoint included in the OpenAPI document.                                            | `false`  | `undefined`            |
+| `tags`           | `string[]`                         | A list of tags used for logical grouping of endpoints in the OpenAPI document.                                     | `false`  | `undefined`            |
+| `headers`        | `ParameterObject[]`                | An array of custom headers to add for this endpoint in the OpenAPI document.                                       | `false`  | `undefined`            |
+| `contentTypes`   | `ContentType[]`                    | A set of content types specified as accepted in the OpenAPI document.                                              | `false`  | `['application/json']` |
+| `extraResponses` | `ResponsesObject`* | An array of custom responses to add for this endpoint in the OpenAPI document in addition to the default response. | `false`  | `undefined`            |
+| `deprecated`     | `boolean`                          | Whether or not to mark an endpoint as deprecated                                                                   | `false`  | `false`                |
+
+* _The `content` field in ResponsesObject is expected to be a `z.ZodType`_
 
 #### CreateOpenApiNodeHttpHandlerOptions
 

--- a/src/generator/schema.ts
+++ b/src/generator/schema.ts
@@ -3,7 +3,7 @@ import { OpenAPIV3 } from 'openapi-types';
 import { z } from 'zod';
 import zodToJsonSchema from 'zod-to-json-schema';
 
-import { OpenApiContentType } from '../types';
+import { OpenApiContentType, ExtraResponse } from '../types';
 import {
   instanceofZodType,
   instanceofZodTypeCoercible,
@@ -189,7 +189,7 @@ export const errorResponseObject: OpenAPIV3.ResponseObject = {
 export const getResponsesObject = (
   schema: unknown,
   example: Record<string, any> | undefined,
-  extraResponses?: OpenAPIV3.ResponsesObject,
+  extraResponses?: Record<string, ExtraResponse>,
 ): OpenAPIV3.ResponsesObject => {
   if (!instanceofZodType(schema)) {
     throw new TRPCError({
@@ -207,12 +207,27 @@ export const getResponsesObject = (
       },
     },
   };
+  const extraResponseObjects = Object.entries(
+    extraResponses || {},
+  ).reduce<OpenAPIV3.ResponsesObject>((responseObjects, entry) => {
+    return {
+      ...responseObjects,
+      [entry[0]]: {
+        ...entry[1],
+        content: {
+          'application/json': {
+            schema: zodSchemaToOpenApiSchemaObject(entry[1].content),
+          },
+        },
+      },
+    };
+  }, {});
 
   return {
     200: successResponseObject,
     default: {
       $ref: '#/components/responses/error',
     },
-    ...extraResponses,
+    ...extraResponseObjects,
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,6 @@ import {
   OpenApiSuccessResponse,
 } from './types';
 import { ZodTypeLikeString, ZodTypeLikeVoid } from './utils/zod';
-import { errorResponseObject as DefaultErrorResponse } from './generator/schema';
 
 export {
   CreateOpenApiAwsLambdaHandlerOptions,
@@ -52,5 +51,4 @@ export {
   OpenApiErrorResponse,
   ZodTypeLikeString,
   ZodTypeLikeVoid,
-  DefaultErrorResponse,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,9 +3,12 @@ import type { RootConfig } from '@trpc/server/dist/core/internals/config';
 import { TRPC_ERROR_CODE_KEY } from '@trpc/server/rpc';
 import type { RouterDef } from '@trpc/server/src/core/router';
 import { OpenAPIV3 } from 'openapi-types';
-import { ZodIssue } from 'zod';
+import { ZodIssue, ZodType } from 'zod';
 
 export type OpenApiMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
+export type ExtraResponse = Omit<OpenAPIV3.ResponseObject, 'content'> & {
+  content: ZodType;
+};
 
 type TRPCMeta = Record<string, unknown>;
 
@@ -26,7 +29,7 @@ export type OpenApiMeta<TMeta = TRPCMeta> = TMeta & {
     tags?: string[];
     headers?: (OpenAPIV3.ParameterBaseObject & { name: string; in?: 'header' })[];
     contentTypes?: OpenApiContentType[];
-    extraResponses?: OpenAPIV3.ResponsesObject;
+    extraResponses?: Record<string, ExtraResponse>;
     deprecated?: boolean;
     example?: {
       request?: Record<string, any>;

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -2135,8 +2135,8 @@ describe('generator', () => {
             path: '/echo',
             extraResponses: {
               400: {
-                ...errorResponseObject,
                 description: 'Bad request',
+                content: z.object({ reason: z.string() }),
               },
             },
           },
@@ -2149,69 +2149,25 @@ describe('generator', () => {
     const openApiDocument = generateOpenApiDocument(appRouter, defaultDocOpts);
 
     expect(openApiSchemaValidator.validate(openApiDocument).errors).toEqual([]);
-    expect(openApiDocument.paths['/echo']!.get!.responses).toMatchInlineSnapshot(`
+    expect(openApiDocument.paths['/echo']!.get!.responses['400']).toMatchInlineSnapshot(`
       Object {
-        "200": Object {
-          "content": Object {
-            "application/json": Object {
-              "example": undefined,
-              "schema": Object {
-                "additionalProperties": false,
-                "properties": Object {
-                  "id": Object {
-                    "type": "string",
-                  },
+        "content": Object {
+          "application/json": Object {
+            "schema": Object {
+              "additionalProperties": false,
+              "properties": Object {
+                "reason": Object {
+                  "type": "string",
                 },
-                "required": Array [
-                  "id",
-                ],
-                "type": "object",
               },
+              "required": Array [
+                "reason",
+              ],
+              "type": "object",
             },
           },
-          "description": "Successful response",
         },
-        "400": Object {
-          "content": Object {
-            "application/json": Object {
-              "schema": Object {
-                "additionalProperties": false,
-                "properties": Object {
-                  "code": Object {
-                    "type": "string",
-                  },
-                  "issues": Object {
-                    "items": Object {
-                      "additionalProperties": false,
-                      "properties": Object {
-                        "message": Object {
-                          "type": "string",
-                        },
-                      },
-                      "required": Array [
-                        "message",
-                      ],
-                      "type": "object",
-                    },
-                    "type": "array",
-                  },
-                  "message": Object {
-                    "type": "string",
-                  },
-                },
-                "required": Array [
-                  "message",
-                  "code",
-                ],
-                "type": "object",
-              },
-            },
-          },
-          "description": "Bad request",
-        },
-        "default": Object {
-          "$ref": "#/components/responses/error",
-        },
+        "description": "Bad request",
       }
     `);
   });


### PR DESCRIPTION
So we can add error response documentation

## Example
```typescript
import { DefaultErrorResponse } from "trpc-openapi";

export const appRouter = t.router({
  getUser: t.procedure
    .meta({
      openapi: {
        method: "GET",
        path: "/get-user",
        extraResponses: {
          400: {
            description: 'Bad request',
            content: z.object({ reason: z.string().describe("The reason") }),
          },
        },
      },
    })
    .input(z.object({ name: z.string().describe("your name") }))
    .output(z.object({ id: z.string(), name: z.string() }))
    .query(({ input }) => {
        /* ... */
    }),
```
